### PR TITLE
Adding bad request error. Fix #5.

### DIFF
--- a/lib/desk_api/request/retry.rb
+++ b/lib/desk_api/request/retry.rb
@@ -45,7 +45,8 @@ module DeskApi
             Errno::ETIMEDOUT,
             'Timeout::Error',
             Faraday::Error::TimeoutError,
-            DeskApi::Error::TooManyRequests
+            DeskApi::Error::TooManyRequests,
+            DeskApi::Error::BadRequest
           ]
         end
       end


### PR DESCRIPTION
Adds `DeskApi::Error::BadRequest` to the error list for retries.