### PR TITLE
Bump addressable gem to newer version

### DIFF
--- a/desk_api.gemspec
+++ b/desk_api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('faraday', '>= 0.8', '< 1.0')
   gem.add_runtime_dependency('simple_oauth', '>= 0.1', '< 0.3')
-  gem.add_runtime_dependency('addressable', '>= 2.3', '< 2.4')
+  gem.add_runtime_dependency('addressable', '>= 2.3', '<= 2.4')
 
   gem.add_development_dependency('rake', '>= 10.1', '< 10.4')
   gem.add_development_dependency('rspec', '>= 2.6', '< 2.15')


### PR DESCRIPTION
No reason not to use the newer version of addressable. All tests pass.
